### PR TITLE
Remove our Google Analytics key

### DIFF
--- a/themes/tuftesque/layouts/partials/header.includes.html
+++ b/themes/tuftesque/layouts/partials/header.includes.html
@@ -24,14 +24,3 @@
 
 <!-- Main CSS file based on Pure blog layout -->
 <link rel="stylesheet" href="{{ "/css/tuftesque.css" | absURL }}">
-
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-92165973-1', 'auto');
-  ga('send', 'pageview');
-
-</script>


### PR DESCRIPTION
:speak_no_evil: I recently realized `tuftesque` had our Google Analytics ID embedded within it accidentally (we have since fixed it, so you can either repull from [tuftesque](https://github.com/nstrayer/tuftesque), or take this PR).